### PR TITLE
fix(backend): mount rangeRush route in app.ts

### DIFF
--- a/Backend/src/app.ts
+++ b/Backend/src/app.ts
@@ -22,6 +22,7 @@ import kenoRouter from "./route/keno";
 // import hgRouter from './route/hg';
 
 import luckyMatchRouter from "./route/luckyMatch";
+import rangeRushRouter from "./route/rangeRush";
 
 import userRouter from "./route/user";
 
@@ -79,6 +80,7 @@ app.use("/horseRace", horseRaceRouter);
 app.use("/oneTwoThree", oneTwoThreeRouter);
 app.use("/keno", kenoRouter);
 app.use("/luckyMatch", luckyMatchRouter);
+app.use("/rangeRush", rangeRushRouter);
 
 // app.use('/l7d', l7dRouter);
 // app.use('/hg', hgRouter);


### PR DESCRIPTION
`rangeRush` router and its validator (`validateRangeRushGameInput`) are implemented and **Range Rush** is listed as `isAvailable: true` in the game portal, but `app.ts` never registered the router — so `POST /rangeRush` 404s.

This adds the missing 2 lines (import + `app.use("/rangeRush", …)`), mirroring the existing `luckyMatch` wiring.

Keeps `dev` consistent with the same fix included in the dev→main promotion (#173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)